### PR TITLE
Add Google Assistant integration via OSC

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,14 @@ SteamVRがデバイスを認識してから本アプリケーションがデバ�
 温度は0 ~ 50度の範囲を(float)0 ~ 1 (avatar/parameters/Humidity)
 <br>
 湿度は0 ~ 100%の範囲を(float)0 ~ 1 (avatar/parameters/Temperature)
+
+Google Assistant テキストクエリ
+<br>
+VRChat から "/assistant/query" アドレスの OSC を受信すると、その引数を Google Assistant API に送信します。
+<br>
+以下の環境変数を設定してください。
+<br>
+・GA_PROJECT_ID<br>
+・GA_MODEL_ID<br>
+・GA_DEVICE_ID<br>
+・GA_ACCESS_TOKEN

--- a/sai_OSCController/GoogleAssistantApi.cs
+++ b/sai_OSCController/GoogleAssistantApi.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public class GoogleAssistantApi
+{
+    readonly string projectId = Environment.GetEnvironmentVariable("GA_PROJECT_ID");
+    readonly string modelId = Environment.GetEnvironmentVariable("GA_MODEL_ID");
+    readonly string deviceId = Environment.GetEnvironmentVariable("GA_DEVICE_ID");
+    readonly string accessToken = Environment.GetEnvironmentVariable("GA_ACCESS_TOKEN");
+
+    string Endpoint => $"https://embeddedassistant.googleapis.com/v1alpha2/projects/{projectId}/deviceModels/{modelId}/devices/{deviceId}:assist";
+
+    readonly HttpClient httpClient = new HttpClient();
+
+    public async Task<string?> SendTextQueryAsync(string text)
+    {
+        if (string.IsNullOrEmpty(accessToken) || string.IsNullOrEmpty(projectId))
+        {
+            Console.WriteLine("Google Assistant environment variables are not set.");
+            return null;
+        }
+
+        var body = new
+        {
+            input = new { text = text },
+            dialog_state_in = new { language_code = "ja-JP" },
+            device_config = new { device_id = deviceId, device_model_id = modelId }
+        };
+
+        var json = JsonConvert.SerializeObject(body);
+        using var req = new HttpRequestMessage(HttpMethod.Post, Endpoint);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        req.Content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        using var res = await httpClient.SendAsync(req);
+        if (!res.IsSuccessStatusCode)
+        {
+            Console.WriteLine($"Google Assistant Error: {(int)res.StatusCode} {res.ReasonPhrase}");
+            var err = await res.Content.ReadAsStringAsync();
+            Console.WriteLine(err);
+            return null;
+        }
+
+        return await res.Content.ReadAsStringAsync();
+    }
+}

--- a/sai_OSCController/OSCReceiver.cs
+++ b/sai_OSCController/OSCReceiver.cs
@@ -116,9 +116,13 @@ public class OSCReceiver
         MainWindow.Instance?.AvatarMover?.Move(type, value);
     }
 
-    void OnHandleAssistantQuery(string text)
+    async UniTaskVoid OnHandleAssistantQuery(string text)
     {
-        assistantApi.SendTextQueryAsync(text).Forget();
+        var response = await assistantApi.SendTextQueryAsync(text);
+        if (response != null)
+        {
+            Console.WriteLine($"Assistant response: {response}");
+        }
     }
     
     void HandleMessage(OscMessage message)
@@ -154,7 +158,7 @@ public class OSCReceiver
             {
                 if (arg is string str)
                 {
-                    OnHandleAssistantQuery(str);
+                    OnHandleAssistantQuery(str).Forget();
                 }
             }
         });

--- a/sai_OSCController/OSCReceiver.cs
+++ b/sai_OSCController/OSCReceiver.cs
@@ -4,10 +4,13 @@ using System.Diagnostics;
 using System.Windows;
 using System.IO;
 using sai_OSCController;
+using System.Text;
+using System.Net.Http;
 
 public class OSCReceiver
 {
     readonly string batFile = "ExitVRChat.bat";
+    GoogleAssistantApi assistantApi = new();
 
     public OSCReceiver()
     {
@@ -112,6 +115,11 @@ public class OSCReceiver
 
         MainWindow.Instance?.AvatarMover?.Move(type, value);
     }
+
+    void OnHandleAssistantQuery(string text)
+    {
+        assistantApi.SendTextQueryAsync(text).Forget();
+    }
     
     void HandleMessage(OscMessage message)
     {
@@ -120,7 +128,8 @@ public class OSCReceiver
             return;
         }
 
-        if (!message.Address.Contains("Button") && !message.Address.Contains("AM"))
+        if (!message.Address.Contains("Button") && !message.Address.Contains("AM") &&
+            !message.Address.StartsWith("/assistant/query"))
         {
             return;
         }
@@ -139,6 +148,14 @@ public class OSCReceiver
             if (message.Address.Contains("avatar/parameters/AM"))
             {
                 OnHandleAvatarMover(message.Address, (float)arg);
+            }
+
+            if (message.Address.StartsWith("/assistant/query"))
+            {
+                if (arg is string str)
+                {
+                    OnHandleAssistantQuery(str);
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- introduce `GoogleAssistantApi` class to send text queries to Google Assistant
- trigger assistant queries in `OSCReceiver` when receiving `/assistant/query`
- document new OSC endpoint and required environment variables

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841677192a4832aac6d4ebaeb81ce26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for sending text queries to Google Assistant via OSC messages from VRChat.
- **Documentation**
  - Updated the README to include instructions and environment variable requirements for the new Google Assistant text query feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->